### PR TITLE
Use ansible_local provisioner with Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ utilized storage increases primarily because of system and chat logs.
 For testing purposes you can provision a virtual machine with a complete setup using
 [Vagrant](https://www.vagrantup.com/). To do so follow the following steps:
 
-1. Install [Vagrant](https://www.vagrantup.com/)
-2. Install [Ansible](https://www.ansible.com/)
+1. Install [VirtualBox](https://www.virtualbox.org/)
+2. Install [Vagrant](https://www.vagrantup.com/)
 3. Run `vagrant up` from the project directory and wait a few minutes, while Vagrant fetches the
    base image from the internet and installs and configures all necessary software.
 4. **Back up your existing Pyrogenesis configuration, as the following steps will override the

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,16 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "debian/testing64"  # TODO: change to bookworm64 once available
 
+  config.vm.provider :virtualbox do |vb|
+      vb.memory = 1024
+  end
+
   config.vm.hostname = "lobby"
 
-  config.vm.provision "ansible" do |ansible|
+  config.vm.provision "shell",
+    inline: "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y acl"
+
+  config.vm.provision "ansible_local" do |ansible|
     ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file}"
     ansible.galaxy_role_file = "requirements.yml"
     ansible.raw_arguments = ["--diff", "--extra-vars", "is_vagrant=true"]


### PR DESCRIPTION
This switches the provisioner used when creating a local lobby VM with Vagrant from "ansible" to "ansible_local". This makes it easier for users on Windows to deploy a local lobby VM, as they don't need to install Ansible anymore, which isn't available for Windows natively.

As Ansible is now running inside the VM, the VM does require more memory than before, however with 1GB that should still be low enough to run on pretty much any computer in use nowadays.