### PR TITLE
Add borgmatic for backups

### DIFF
--- a/roles/borgmatic/defaults/main.yml
+++ b/roles/borgmatic/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+borg_repo_location: /opt/backups/local.borg

--- a/roles/borgmatic/files/borgmatic-service-override.conf
+++ b/roles/borgmatic/files/borgmatic-service-override.conf
@@ -1,0 +1,4 @@
+[Service]
+# necessary for `ejabberdctl backup` to work
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_SYS_RESOURCE CAP_CHOWN CAP_FOWNER
+PrivateTmp=false

--- a/roles/borgmatic/files/dump-ejabberd.sh
+++ b/roles/borgmatic/files/dump-ejabberd.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Helper script for borgmatic to dump ejabberd databases.
+
+set -e
+
+mkdir -p /tmp/borgmatic/ejabberd/
+
+ejabberdctl backup /tmp/ejabberd.backup
+
+# ejabberd uses PrivateTmp, so lets use this hack to copy the backup
+# to the place where we expect it for borgmatic.
+PRIVATE_TMP_BACKUP_LOCATION="$(find /tmp/systemd-private-* -type f -name ejabberd.backup)"
+
+if [ "$PRIVATE_TMP_BACKUP_LOCATION" = "" ]; then
+  echo "Couldn't find generated backup"
+  exit 1
+fi
+
+if [ $(echo "$PRIVATE_TMP_BACKUP_LOCATION" | wc -l) -gt 1 ]; then
+  echo "Something went wrong. Found more than one backup."
+  exit 1
+fi
+
+mv "$PRIVATE_TMP_BACKUP_LOCATION" /tmp/borgmatic/ejabberd/ejabberd.backup
+chmod 600 /tmp/borgmatic/ejabberd/ejabberd.backup
+chown root:root /tmp/borgmatic/ejabberd/ejabberd.backup

--- a/roles/borgmatic/files/dump-sqlite.sh
+++ b/roles/borgmatic/files/dump-sqlite.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Helper script for borgmatic to dump SQLite databases.
+# Necessary as the version of borgmatic in Debian/bookworm doesn't
+# support backing up SQLite databases natively yet.
+
+set -e
+
+DB_PATH="$1"
+DB_NAME="$2"
+
+if [ "$DB_PATH" = "" ]; then
+  echo "Usage: $0 database_path database_name"
+  exit 1
+fi
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "Invalid database path"
+  exit 1
+fi
+
+if [ "$DB_NAME" = "" ]; then
+  echo "Missing database name."
+  exit 1
+fi
+
+mkdir -p /tmp/borgmatic/sqlite/
+
+sqlite3 "$DB_PATH" .dump > "/tmp/borgmatic/sqlite/$DB_NAME.sql"

--- a/roles/borgmatic/tasks/main.yml
+++ b/roles/borgmatic/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+- name: Install borgmatic
+  ansible.builtin.apt:
+    name: borgmatic
+    state: present
+
+- name: Create config directory
+  ansible.builtin.file:
+    path: /etc/borgmatic
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Create backup scripts
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    owner: root
+    group: root
+    mode: 0700
+  loop:
+    - dump-ejabberd.sh
+    - dump-sqlite.sh
+
+- name: Configure borgmatic
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: /etc/borgmatic/config.yaml
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Create borg repository directory
+  ansible.builtin.file:
+    path: "{{ borg_repo_location }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Create Borg repository
+  ansible.builtin.command: borgmatic rcreate --encryption none
+  args:
+    creates: "{{ borg_repo_location }}/data"
+
+- name: Create directory for borgmatic specific systemd configuration
+  ansible.builtin.file:
+    path: /etc/systemd/system/borgmatic.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Install systemd override file for borgmatic
+  ansible.builtin.copy:
+    src: borgmatic-service-override.conf
+    dest: /etc/systemd/system/borgmatic.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Ensure systemd units for borgmatic are enabled
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: true
+    daemon_reload: true
+  loop:
+    - borgmatic.service
+    - borgmatic.timer

--- a/roles/borgmatic/templates/config.yaml.j2
+++ b/roles/borgmatic/templates/config.yaml.j2
@@ -1,0 +1,29 @@
+---
+location:
+    source_directories:
+        - /tmp/borgmatic
+
+    repositories:
+        - {{ borg_repo_location }}
+
+retention:
+    keep_daily: 7
+    keep_weekly: 5
+    keep_monthly: 12
+    keep_yearly: 5
+
+consistency:
+    checks:
+        - name: repository
+        - name: archives
+          frequency: 2 weeks
+
+hooks:
+    before_backup:
+        - /usr/local/bin/dump-ejabberd.sh
+{% for bot in bots | selectattr('type', 'in', ['echelon', 'chat-monitor', 'moderation']) %}
+        - /usr/local/bin/dump-sqlite.sh /opt/lobby/{{ bot.name }}/db.sqlite {{ bot.name }}
+{% endfor %}
+
+    after_backup:
+        - rm -R /tmp/borgmatic/

--- a/site.yml
+++ b/site.yml
@@ -23,6 +23,7 @@
     - ejabberd
     - python
     - lobby_bots
+    - borgmatic
   post_tasks:
     - name: Push Ansible variable file with sensitive lobby parameters
       ansible.builtin.copy:


### PR DESCRIPTION
This adds daily deduplicating backups of the ejabberd database and lobby bot databases using borgmatic. While backups are for now only stored locally, borgmatic would make it easy to add off-site destinations for backups as well.