### PR TITLE
Increase traffic rate for bots

### DIFF
--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -245,6 +245,9 @@ shaper:
     rate: 1000
     burst_size: 20000
   fast: 200000
+  faster:
+    rate: 1000000
+    burst_size: 10000000
 
 shaper_rules:
   max_user_sessions: 10
@@ -253,7 +256,7 @@ shaper_rules:
     100: all
   c2s_shaper:
     - none: admin
-    - fast: bots
+    - faster: bots
     - normal
   s2s_shaper: fast
 


### PR DESCRIPTION
As it turns out 200KB/s isn't enough bandwidth for the bots to send out updates when many players are online. Instead they appear to be laggy, as they send out updates for game lists and ratings delayed. To avoid this laggyness while still keeping some shaping for the bots in place, this increases the available for bots to 1MB/s, with a burst rate of 10MB/s. While this fixes this problem for now, moving to PubSub would be a more elegant solution.