### PR TITLE
Ensure ejabberd is running before running commands

### DIFF
--- a/roles/ejabberd/tasks/main.yml
+++ b/roles/ejabberd/tasks/main.yml
@@ -90,6 +90,12 @@
     state: restarted
   when: localhost_cert_exists.stat.isreg is not defined
 
+- name: Ensure ejabberd is enabled and running
+  ansible.builtin.systemd:
+    name: ejabberd
+    enabled: true
+    state: started
+
 - name: Create contrib modules directory
   ansible.builtin.file:
     path: /opt/ejabberd-modules/sources/


### PR DESCRIPTION
The Ansible playbook contains several tasks which require ejabberd to be running to succeed. However, the playbook didn't ensure that ejabberd was running, so manually stopping ejabberd prior to running the playbook would result in errors. This commit fixes that by ensuring ejabberd is enabled and started before running the tasks which require it to run.

Fixes #5