### PR TITLE
Allow unlimited bandwidth for bots again

### DIFF
--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -253,7 +253,7 @@ shaper_rules:
     100: all
   c2s_shaper:
     - none: admin
-    - fast: bots
+    - none: bots
     - normal
   s2s_shaper: fast
 


### PR DESCRIPTION
This restores the behavior prior to the lobby migration of granting the bots unlimited bandwidth for sending XMPP stanzas. That's necessary, as XpartaMuPP has to send a lot of data when many players are online and many games get hosted. Prior tries increasing the existing rate limit didn't succeed as XpartaMuPP needs that much traffic in such a situation that traffic shaping in general doesn't make much sense.

While this change fixes this problem for now, moving to PubSub would be a more elegant solution.