### PR TITLE
Increase size of journal files

### DIFF
--- a/roles/misc/files/journal-size.conf
+++ b/roles/misc/files/journal-size.conf
@@ -1,0 +1,3 @@
+[Journal]
+SystemMaxUse=4G
+SystemKeepFree=2G

--- a/roles/misc/handlers/main.yml
+++ b/roles/misc/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted

--- a/roles/misc/tasks/main.yml
+++ b/roles/misc/tasks/main.yml
@@ -38,6 +38,23 @@
     enabled: true
     state: started
 
+- name: Create directory for journald config drop-ins
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Configure journald
+  ansible.builtin.copy:
+    src: journal-size.conf
+    dest: /etc/systemd/journald.conf.d/journal-size.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart journald
+
 # That's a workaround to ensure the bots always connect to localhost,
 # as Slixmpp currently doesn't honor explicitly configured addresses
 # used to connect for reconnections.


### PR DESCRIPTION
To be able to keep more than a few hours worth of logs on the official 0 A.D. lobby server, this increases the size of journald's journal files from their default of 10% of the file system size to up to 4GB. Most of the log volume generated there comes from ejabberd and the lobby bots.