### PR TITLE
Use debian/bookworm64 Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "debian/testing64"  # TODO: change to bookworm64 once available
+  config.vm.box = "debian/bookworm64"
 
   config.vm.provider :virtualbox do |vb|
       vb.memory = 1024


### PR DESCRIPTION
When the lobby infrastructure got set up using Ansible, it was done based on Debian Bookworm, which was still in testing back then. As there wasn't an official Debian Bookworm Vagrant Box yet, the local Vagrant setup used the `debian/testing64` Vagrant box instead. As `debian/bookworm64` is available now, we can use it to ensure a local instance running in Vagrant in future still uses the same base as the official lobby instance.