### PR TITLE
Update TLS-related options for the lobby bots

### DIFF
--- a/roles/lobby_bots/templates/echelon-systemd-service.j2
+++ b/roles/lobby_bots/templates/echelon-systemd-service.j2
@@ -10,7 +10,7 @@ Environment=PATH={{ lobby_bot_base_dir }}/{{ bot.name }}/code/bin
 EnvironmentFile={{ lobby_config_dir }}/{{ bot.name }}
 ExecStart=python3 {{ lobby_bot_base_dir }}/{{ bot.name }}/code/bin/echelon \
           --login ${LOGIN} --password ${PASSWORD} --nickname ${NICKNAME} --domain ${HOST} \
-          --room ${ROOM} -d -t \
+          --room ${ROOM} -d --no-verify \
            --database-url sqlite:////{{ lobby_bot_base_dir }}/{{ bot.name }}/db.sqlite
 Restart=on-failure
 

--- a/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
+++ b/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
@@ -10,7 +10,7 @@ Environment=PATH={{ lobby_bot_base_dir }}/{{ bot.name }}/code/bin
 EnvironmentFile={{ lobby_config_dir }}/{{ bot.name }}
 ExecStart=python3 {{lobby_bot_base_dir }}/{{ bot.name }}/code/bin/xpartamupp \
           --login ${LOGIN} --password ${PASSWORD} --nickname ${NICKNAME} --domain ${HOST} \
-          --room ${ROOM} -d -t
+          --room ${ROOM} -d --no-verify
 Restart=on-failure
 
 NoNewPrivileges=true


### PR DESCRIPTION
A [recent change for the lobby bots][1] changed how XpartaMuPP and EcheLOn handle TLS-encrypted connections. This requires updates to the command line parameters used to connect them to the XMPP server, as the `-t`/`--disable-tls` option isn't available anymore, but instead a `--no-verify` option is offered. Without this change for the options, running the bots will fail, if they include the change in command line options.

Please mind that specifying `--no-verify` wouldn't be necessary for the official lobby, as properly signed certificates are provided there, but is in here instead to continue to provide support for running the bots with the Vagrant setup, which usually doesn't have properly signed certificates.

[1]: https://github.com/0ad/lobby-bots/pull/22