### PR TITLE
Use online backup API for SQLite backups

### DIFF
--- a/roles/borgmatic/files/dump-sqlite.sh
+++ b/roles/borgmatic/files/dump-sqlite.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 # Helper script for borgmatic to dump SQLite databases.
+#
 # Necessary as the version of borgmatic in Debian/bookworm doesn't
-# support backing up SQLite databases natively yet.
+# support backing up SQLite databases natively and we do want to use
+# the "backup" command instead of the "dump" command used by borgmatic
+# anyway.
 
 set -e
 
@@ -26,4 +29,4 @@ fi
 
 mkdir -p /tmp/borgmatic/sqlite/
 
-sqlite3 "$DB_PATH" .dump > "/tmp/borgmatic/sqlite/$DB_NAME.sql"
+sqlite3 "$DB_PATH" ".timeout 10000" ".backup /tmp/borgmatic/sqlite/$DB_NAME.sqlite"


### PR DESCRIPTION
This improves how backups for SQLite databases are done. Instead of dumping the database content into a text file, using the "dump" command, a copy of the actual database is now being done by by the "backup" command. This is much faster than using the "dump" command. In addition this sets a busy timeout of 10s before doing the backup to avoid failures when the database is briefly locked by another process when the backup starts.