### PR TITLE
Disable SASL PLAIN authentication

### DIFF
--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -130,7 +130,8 @@ acme:
 ## Disabling digest-md5 SASL authentication. digest-md5 requires plain-text
 ## password storage (see auth_password_format option).
 disable_sasl_mechanisms:
-  - "digest-md5"
+  - "PLAIN"
+  - "DIGEST-MD5"
   - "X-OAUTH2"
 
 s2s_use_starttls: required


### PR DESCRIPTION
This disables the PLAIN mechanism for SASL authentication which would transmit a users password as plain text during. Instead only the SCRAM-SHA-1 and SCRAM-SHA-1-PLUS mechanisms are supported now.

As SCRAM-SHA1 and SCRAM-SHA1-PLUS are mandatory to be supported by XMPP clients and servers and were prioritised higher than the PLAIN mechansim in the preference order by ejabberd before, this doesn't change how XMPP clients connect, but avoids unintentional use of the PLAIN mechanism in rare circumstances.

Please note that these changes only affect authentication of registered users. During inband registration the password is still submitted in plain text.