### PR TITLE
Limit the syscalls available to the lobby bots

### DIFF
--- a/roles/lobby_bots/templates/echelon-systemd-service.j2
+++ b/roles/lobby_bots/templates/echelon-systemd-service.j2
@@ -27,6 +27,13 @@ ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
+SystemCallArchitectures=native
+SystemCallFilter=access arch_prctl brk close connect epoll_create1 epoll_ctl epoll_wait fchmod
+SystemCallFilter=fcntl fdatasync futex getcwd getdents64 geteuid getpeername getpid getrandom
+SystemCallFilter=getsockname getsockopt gettid ioctl lseek mmap mprotect mremap munmap newfstatat
+SystemCallFilter=openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq rt_sigaction sendto
+SystemCallFilter=set_robust_list setsockopt set_tid_address socket socketpair sysinfo uname unlink
+SystemCallFilter=write
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/lobby_bots/templates/moderation-systemd-service.j2
+++ b/roles/lobby_bots/templates/moderation-systemd-service.j2
@@ -28,6 +28,13 @@ ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
+SystemCallArchitectures=native
+SystemCallFilter=access arch_prctl brk close connect epoll_create1 epoll_ctl epoll_wait fchmod
+SystemCallFilter=fcntl fdatasync futex getcwd getdents64 geteuid getpeername getpid getrandom
+SystemCallFilter=getsockname getsockopt gettid ioctl lseek mmap mprotect mremap munmap newfstatat
+SystemCallFilter=openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq rt_sigaction sendto
+SystemCallFilter=set_robust_list setsockopt set_tid_address socket socketpair sysinfo uname unlink
+SystemCallFilter=write
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
+++ b/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
@@ -26,6 +26,13 @@ ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
+SystemCallArchitectures=native
+SystemCallFilter=access arch_prctl brk close connect epoll_create1 epoll_ctl epoll_wait fchmod
+SystemCallFilter=fcntl fdatasync futex getcwd getdents64 geteuid getpeername getpid getrandom
+SystemCallFilter=getsockname getsockopt gettid ioctl lseek mmap mprotect mremap munmap newfstatat
+SystemCallFilter=openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq rt_sigaction sendto
+SystemCallFilter=set_robust_list setsockopt set_tid_address socket socketpair sysinfo uname unlink
+SystemCallFilter=write
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This reduces the attack surface of the bots, as it limits the system calls they're allowed to use to the ones they actually need. Attackers gaining remote code execution will be limited to these system calls as well and can't exploit potential security vulnerabilities in other system calls to elevate privileges.