### PR TITLE
Ensure the local timezone is set to UTC

### DIFF
--- a/roles/misc/tasks/main.yml
+++ b/roles/misc/tasks/main.yml
@@ -30,7 +30,16 @@
       - sqlite3
       - sudo
       - systemd-timesyncd
+      - tzdata
     state: present
+
+- name: Ensure timezone is set to UTC
+  ansible.builtin.file:
+    src: /usr/share/zoneinfo/Etc/UTC
+    path: /etc/localtime
+    owner: root
+    group: root
+    state: link
 
 - name: Enable systemd timesyncd
   ansible.builtin.systemd:


### PR DESCRIPTION
When the lobby server got set up the last time its timezone got set to Europe/Berlin. That undesirable as some applications just use the local time without recording timezone information (e.g. when writing logs). Especially if combined with changes in daylight saving time, this leads to situations where dates are ambiguous. Using UTC instead avoids such problems.