### PR TITLE
Delete lobby bots not present anymore

### DIFF
--- a/roles/lobby_bots/handlers/main.yml
+++ b/roles/lobby_bots/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/roles/lobby_bots/tasks/main.yml
+++ b/roles/lobby_bots/tasks/main.yml
@@ -147,3 +147,57 @@
   loop: "{{ bots }}"
   loop_control:
     loop_var: bot
+
+- name: Get list of custom systemd services
+  ansible.builtin.command:
+    cmd: "ls -1 /etc/systemd/system/"
+  changed_when: false
+  register: custom_systemd_services
+
+- name: Check for lobby bot systemd service files
+  ansible.builtin.command:
+    cmd: "grep -i Pyrogenesis /etc/systemd/system/{{ service_file }}"
+  changed_when: false
+  failed_when: false
+  loop_control:
+    loop_var: service_file
+  loop: "{{ custom_systemd_services.stdout_lines }}"
+  register: pyrogenesis_systemd_services
+
+- name: Stop outdated systemd services
+  ansible.builtin.systemd:
+    name: "{{ bot_name }}"
+    state: stopped
+  loop: >
+    {{ pyrogenesis_systemd_services.results | selectattr('rc', 'equalto', 0) |
+    map(attribute='service_file') | map('regex_replace', '^(.*)\.service$', '\1') }}
+  loop_control:
+    loop_var: bot_name
+  when: "bot_name not in bots | map(attribute='name')"
+
+- name: Remove outdated systemd service files
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ bot_name }}.service"
+    state: absent
+  loop: >
+    {{ pyrogenesis_systemd_services.results | selectattr('rc', 'equalto', 0) |
+    map(attribute='service_file') | map('regex_replace', '^(.*)\.service$', '\1') }}
+  loop_control:
+    loop_var: bot_name
+  when: "bot_name not in bots | map(attribute='name')"
+  notify: Reload systemd
+
+- name: Check for existing lobby bot directories
+  ansible.builtin.command:
+    cmd: "ls -1 {{ lobby_bot_base_dir }}/"
+  changed_when: false
+  register: lobby_bot_dirs
+
+- name: Remove outdated lobby bot directories
+  ansible.builtin.file:
+    path: "{{ lobby_bot_base_dir }}/{{ bot_name }}"
+    state: absent
+  loop: "{{ lobby_bot_dirs.stdout_lines }}"
+  loop_control:
+    loop_var: bot_name
+  when: "bot_name not in bots | map(attribute='name')"


### PR DESCRIPTION
This ensures the files belonging to bots removed from the configuration are removed from lobby instances as well.