### PR TITLE
Set a more restrictive default umask

### DIFF
--- a/roles/misc/tasks/main.yml
+++ b/roles/misc/tasks/main.yml
@@ -1,4 +1,31 @@
 ---
+- name: Set the default umask to 077
+  ansible.builtin.lineinfile:
+    path: /etc/login.defs
+    regexp: '^UMASK\t'
+    line: "UMASK\t\t077"
+    state: present
+
+- name: Use pam_umask to enforce the file mode creation umask
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/common-session
+    regexp: 'pam_umask\.so'
+    line: "session\toptional\tpam_umask.so"
+    state: present
+
+- name: Get all skeleton files
+  ansible.builtin.find:
+    paths: /etc/skel
+    hidden: true
+    recurse: true
+  register: skeleton_files
+
+- name: Change file permissions of skeleton files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    mode: 0700
+  loop: "{{ skeleton_files.files }}"
+
 - name: Ensure undesired ntp services aren't installed
   ansible.builtin.apt:
     name:


### PR DESCRIPTION
By default Debian uses a umask of 022, which results in newly created files being world readable. That's not desired for our use case, as we want to restrict access of different users, especially the lobby bots, as much as possible. Therefore, this changes the default umask from 022 to 077 to ensure only the creator of a file can access it by default.

When updating an existing lobby server, the file permissions for already existing lobby bots have to be updated manually to make use of the more restrictive permissions.