### PR TITLE
Increase the maximum journal size from 4GB to 10GB

### DIFF
--- a/roles/misc/files/journal-size.conf
+++ b/roles/misc/files/journal-size.conf
@@ -1,3 +1,3 @@
 [Journal]
-SystemMaxUse=4G
+SystemMaxUse=10G
 SystemKeepFree=2G


### PR DESCRIPTION
As it turns out for the given log volume we have right now, 4GB is a little bit too small to hold more than just a few days of logs, so let's increase the limit for the journal size to be able to keep logs for longer, if the underlying file system has enough free space.

Unfortunately journald doesn't support a relative size for `SystemMaxUse`, so we have to use an absolute value here. However, as `SystemKeepFree` is set as well, it's ensured journald doesn't fill up the whole file system the journal is stored on.