### PR TITLE
Use config files for the lobby bots

### DIFF
--- a/config-lobby-vagrant.yml
+++ b/config-lobby-vagrant.yml
@@ -22,11 +22,13 @@ bots: [
     "source": "git+https://github.com/0ad/lobby-bots@master",
     "type": "xpartamupp",
     "config": {
-      "LOGIN": "xpartamupp",
-      "PASSWORD": xpartamupp,
-      "NICKNAME": "WFGBot",
-      "HOST": "localhost",
-      "ROOM": "arena"
+      "login": "xpartamupp",
+      "password": xpartamupp,
+      "nickname": "WFGBot",
+      "domain": "localhost",
+      "room": "arena",
+      "no_verify": true,
+      "verbosity": 3
     }
   },
   {
@@ -35,11 +37,13 @@ bots: [
     "source": "git+https://github.com/0ad/lobby-bots@master",
     "type": "echelon",
     "config": {
-      "LOGIN": "echelon",
-      "PASSWORD": echelon,
-      "NICKNAME": "RatingsBot",
-      "HOST": "localhost",
-      "ROOM": "arena"
+      "login": "echelon",
+      "password": echelon,
+      "nickname": "RatingsBot",
+      "domain": "localhost",
+      "room": "arena",
+      "no_verify": true,
+      "verbosity": 3
     }
   },
   {
@@ -48,12 +52,14 @@ bots: [
     "source": "git+https://github.com/0ad/lobby-bots@master",
     "type": "moderation",
     "config": {
-      "LOGIN": "moderation-bot",
-      "PASSWORD": "moderation-bot",
-      "NICKNAME": "ModerationBot",
-      "HOST": "localhost",
-      "ROOMS": "arena",
-      "COMMAND_ROOM": "moderation"
+      "login": "moderation-bot",
+      "password": "moderation-bot",
+      "nickname": "ModerationBot",
+      "domain": "localhost",
+      "rooms": ["arena"],
+      "command_room": "moderation",
+      "no_verify": true,
+      "verbosity": 3
     }
   },
 ]

--- a/filter_plugins/to_toml.py
+++ b/filter_plugins/to_toml.py
@@ -1,0 +1,47 @@
+import os
+
+from ansible.errors import AnsibleFilterTypeError
+
+
+class FilterModule:
+
+    @classmethod
+    def convert_value(cls, value):
+        if isinstance(value, (list, tuple)):
+            l = [cls.convert_value(i) for i in value]
+            return "[ " + ", ".join(l) + " ]"
+        elif isinstance(value, dict):
+            l = [f"{k} = {cls.convert_value(v)}" for k, v in value.items()]
+            return "{ " + ", ".join(l) + " }"
+        elif isinstance(value, str):
+            return f"\"{value}\""
+        elif isinstance(value, bool):
+            return "true" if value else "false"
+        else:
+            return str(value)
+
+    @staticmethod
+    def to_toml(value):
+        """Convert a dictionary to TOML.
+
+        This is a very naive, but good enough Jinja filter to convert a
+        dictionary to TOML.
+
+        Using a library like `tomli-w` would be more elegant, but would
+        add an additional dependency for being able to run the Ansible
+        code.
+        """
+        if not isinstance(value, dict):
+            raise AnsibleFilterTypeError("Data to be converted to TOML needs to be a dictionary, "
+                                         "got %s instead" % type(value))
+
+        new_value = ""
+        for key, value2 in value.items():
+            converted_value = FilterModule.convert_value(value2)
+            new_value += f"{key} = {converted_value}" + os.linesep
+        return new_value
+
+    def filters(self):
+        return {
+            'to_toml': self.to_toml
+        }

--- a/roles/lobby_bots/tasks/main.yml
+++ b/roles/lobby_bots/tasks/main.yml
@@ -88,15 +88,23 @@
     state: directory
     owner: root
     group: root
-    mode: 0700
+    mode: 0755
 
-- name: Create config file
-  ansible.builtin.template:
-    src: environment-file.j2
-    dest: "{{ lobby_bots_config_dir }}/{{ bot.name }}"
-    owner: root
+- name: Delete old config files
+  ansible.builtin.file:
+    path: "{{ lobby_bots_config_dir }}/{{ bot.name }}"
+    state: absent
+  loop: "{{ bots }}"
+  loop_control:
+    loop_var: bot
+
+- name: Create config files
+  ansible.builtin.copy:
+    content: "{{ bot.config | to_toml }}"
+    dest: "{{ lobby_bots_config_dir }}/{{ bot.name }}.toml"
+    owner: "{{ bot.name }}"
     group: root
-    mode: 0600
+    mode: 0660
   loop: "{{ bots }}"
   loop_control:
     loop_var: bot
@@ -113,7 +121,7 @@
 
 - name: Create ejabberd accounts if they don't exist yet
   ansible.builtin.command: "ejabberdctl register {{ user.bot.jid.split('@')[0] }}
-    {{ user.bot.jid.split('@')[1] }} {{ user.bot.config.PASSWORD }}"
+    {{ user.bot.jid.split('@')[1] }} {{ user.bot.config.password }}"
   when: user.rc == 1
   changed_when: false
   loop: "{{ ejabberd_users_present.results }}"

--- a/roles/lobby_bots/templates/echelon-systemd-service.j2
+++ b/roles/lobby_bots/templates/echelon-systemd-service.j2
@@ -7,11 +7,9 @@ After=network.target ejabberd.service
 Type=exec
 User={{ bot.name }}
 Environment=PATH={{ lobby_bots_base_dir }}/{{ bot.name }}/code/bin
-EnvironmentFile={{ lobby_bots_config_dir }}/{{ bot.name }}
 ExecStart=python3 {{ lobby_bots_base_dir }}/{{ bot.name }}/code/bin/echelon \
-          --login ${LOGIN} --password ${PASSWORD} --nickname ${NICKNAME} --domain ${HOST} \
-          --room ${ROOM} -d --no-verify \
-           --database-url sqlite:////{{ lobby_bots_base_dir }}/{{ bot.name }}/db.sqlite
+          --config-file {{ lobby_bots_config_dir }}/{{ bot.name }}.toml \
+          --database-url sqlite:////{{ lobby_bots_base_dir }}/{{ bot.name }}/db.sqlite
 Restart=on-failure
 
 NoNewPrivileges=true

--- a/roles/lobby_bots/templates/environment-file.j2
+++ b/roles/lobby_bots/templates/environment-file.j2
@@ -1,3 +1,0 @@
-{% for key, value in bot.config.items() %}
-{{ key }}={{ value }}
-{% endfor %}

--- a/roles/lobby_bots/templates/moderation-systemd-service.j2
+++ b/roles/lobby_bots/templates/moderation-systemd-service.j2
@@ -7,11 +7,8 @@ After=network.target ejabberd.service
 Type=exec
 User={{ bot.name }}
 Environment=PATH={{ lobby_bots_base_dir }}/{{ bot.name }}/code/bin
-EnvironmentFile={{ lobby_bots_config_dir }}/{{ bot.name }}
 ExecStart=python3 {{ lobby_bots_base_dir }}/{{ bot.name }}/code/bin/modbot \
-          --login ${LOGIN} --password ${PASSWORD} --nickname ${NICKNAME} --domain ${HOST} \
-          --rooms {%- for room in bot.config.ROOMS.split(" ") %} {{ room }}{%- endfor %} -d \
-          --command-room ${COMMAND_ROOM} --no-verify \
+          --config-file {{ lobby_bots_config_dir }}/{{ bot.name }}.toml \
           --database-url sqlite:////{{ lobby_bots_base_dir }}/{{ bot.name }}/db.sqlite
 Restart=on-failure
 

--- a/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
+++ b/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
@@ -7,10 +7,8 @@ After=network.target ejabberd.service
 Type=exec
 User={{ bot.name }}
 Environment=PATH={{ lobby_bots_base_dir }}/{{ bot.name }}/code/bin
-EnvironmentFile={{ lobby_bots_config_dir }}/{{ bot.name }}
 ExecStart=python3 {{lobby_bots_base_dir }}/{{ bot.name }}/code/bin/xpartamupp \
-          --login ${LOGIN} --password ${PASSWORD} --nickname ${NICKNAME} --domain ${HOST} \
-          --room ${ROOM} -d --no-verify
+          --config-file {{ lobby_bots_config_dir }}/{{ bot.name }}.toml
 Restart=on-failure
 
 NoNewPrivileges=true


### PR DESCRIPTION
Instead of using environment variables for configuration, this switches to using configuration files for the configuration of the lobby bots. This ensures that that sensitive configuration values aren't visible in the process list anymore.

Deploying this requires adjusting the lobby configuration files to account for the changed key names. An example for that is included in the changes to `config-lobby-vagrant.yml` as part of this commit.