### PR TITLE
Change nicks of bots for Vagrant

### DIFF
--- a/config-lobby-vagrant.yml
+++ b/config-lobby-vagrant.yml
@@ -24,7 +24,7 @@ bots: [
     "config": {
       "login": "xpartamupp",
       "password": xpartamupp,
-      "nickname": "WFGBot",
+      "nickname": "XpartaMuPP",
       "domain": "localhost",
       "room": "arena",
       "no_verify": true,
@@ -39,7 +39,7 @@ bots: [
     "config": {
       "login": "echelon",
       "password": echelon,
-      "nickname": "RatingsBot",
+      "nickname": "EcheLOn",
       "domain": "localhost",
       "room": "arena",
       "no_verify": true,


### PR DESCRIPTION
This changes the nicks of EcheLOn and XpartaMuPP when running the lobby with Vagrant so they match the local parts of the JID. This is to avoid triggering the JID-nick-mismatch detection which would let the moderation bot kick the other bots from the lobby, unless they were added to the list of exemptions.