### PR TITLE
Update to ejabberd 23.10

### DIFF
--- a/roles/apt/tasks/main.yml
+++ b/roles/apt/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Enable backports for Debian 12 (Bookworm)
+  ansible.builtin.lineinfile:
+    path: /etc/apt/sources.list
+    regexp: '^deb https://deb.debian.org/debian bookworm-backports main'
+    line: deb https://deb.debian.org/debian bookworm-backports main
+
+- name: Enable source package backports for Debian 12 (Bookworm)
+  ansible.builtin.lineinfile:
+    path: /etc/apt/sources.list
+    regexp: '^deb-src https://deb.debian.org/debian bookworm-backports main'
+    line: deb-src https://deb.debian.org/debian bookworm-backports main
+
 - name: Update the apt cache
   ansible.builtin.apt:
     update_cache: true

--- a/roles/ejabberd/tasks/main.yml
+++ b/roles/ejabberd/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 - name: Install ejabberd
   ansible.builtin.apt:
-    name: ejabberd
+    name: ejabberd=23.10*
     state: present
+    default_release: bookworm-backports
 
 - name: Add ejabberd user to certusers group
   ansible.builtin.user:
@@ -113,23 +114,6 @@
     mode: 0644
     directory_mode: 0755
 
-- name: Restart ejabberd  # noqa: no-handler
-  ansible.builtin.systemd:
-    name: ejabberd
-    state: restarted
-  when: ejabberd_default.changed
-
-- name: Check whether mod_ipstamp is already installed
-  ansible.builtin.shell: ejabberdctl modules_installed | grep mod_ipstamp  # noqa: risky-shell-pipe
-  failed_when: false
-  changed_when: false
-  register: mod_ipstamp_installed
-
-- name: Install mod_ipstamp module
-  ansible.builtin.command: ejabberdctl module_install mod_ipstamp
-  when: mod_ipstamp_installed.rc != 0
-  changed_when: false
-
 - name: Create directories for lobby logs
   ansible.builtin.file:
     path: /var/log/ejabberd/muc
@@ -148,9 +132,15 @@
     lstrip_blocks: true
   register: ejabberd_config
 
-- name: Reload config to enable the mod_ipstamp module
-  ansible.builtin.command: ejabberdctl reload_config  # noqa: no-handler
-  when: ejabberd_config.changed
+- name: Restart ejabberd  # noqa: no-handler
+  ansible.builtin.systemd:
+    name: ejabberd
+    state: restarted
+  when: ejabberd_default.changed
+
+- name: Reload ejabberd config
+  ansible.builtin.command: ejabberdctl reload_config
+  when: ejabberd_config.changed and not ejabberd_default.changed
   changed_when: false
 
 - name: Create MUC rooms

--- a/roles/ejabberd/templates/ejabberd-default.j2
+++ b/roles/ejabberd/templates/ejabberd-default.j2
@@ -94,10 +94,11 @@
 #.
 #' ERL_OPTIONS: Additional Erlang options
 #
-# The next variable allows to specify additional options passed to erlang while
-# starting ejabberd. Some useful options are -noshell, -detached, -heart. When
-# ejabberd is started from an init.d script options -noshell and -detached are
-# added implicitly. See erl(1) for more info.
+# The next variable allows to specify additional options passed to
+# all commands using erlang interpreter. This applies to starting
+# ejabberd server itself but also auxiliary commands like for example
+# starting debug shell. See erl(1) for list of commands that can be
+# used here.
 #
 # It might be useful to add "-pa /usr/local/lib/ejabberd/ebin" if you
 # want to add local modules in this path.
@@ -105,6 +106,20 @@
 # Default: "-env ERL_CRASH_DUMP_BYTES 0"
 #
 ERL_OPTIONS="-env ERL_CRASH_DUMP_BYTES 0"
+
+#.
+#' EJABBERD_OPTS: Additional Erlang options to start ejabberd
+#
+# The next variable allows to specify additional options passed to erlang while
+# starting ejabberd. Some useful options are -noshell, -detached, -heart. When
+# ejabberd is started from an init.d script options -noshell and -detached are
+# added implicitly. See erl(1) for more info.
+#
+# For example you can use value "-heart -env HEART_BEAT_TIMEOUT 120 -env ERL_CRASH_DUMP_SECONDS 60"
+#
+# Default: ""
+#
+#EJABBERD_OPTS=""
 
 #.
 #' ERLANG_NODE: Erlang node name

--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -258,6 +258,9 @@ shaper_rules:
     - normal
   s2s_shaper: fast
 
+install_contrib_modules:
+  - mod_ipstamp
+
 modules:
   mod_adhoc: {}
   mod_admin_extra: {}


### PR DESCRIPTION
Ejabberd 23.01 contains a bug causing the outcast affiliation to be without effect for moderated MUC rooms. That's fixed in ejabberd 23.10.