### PR TITLE
Fix the maximum number of users in a MUC room

### DIFF
--- a/roles/ejabberd/tasks/lobby_muc_room.yml
+++ b/roles/ejabberd/tasks/lobby_muc_room.yml
@@ -24,11 +24,3 @@
     {{ room.key | split('@') | last }} description '{{ room.value }}'"
   when: room_exists.rc == 1
   changed_when: false
-
-# Somehow the max_users default room option in ejabberd.yml doesn't
-# seem to work, so we have to manually do it here.
-- name: Set maximum room users
-  ansible.builtin.command: "ejabberdctl change_room_option {{ room.key | split('@') | first }}
-    {{ room.key | split('@') | last }} max_users 1000"
-  when: room_exists.rc == 1
-  changed_when: false

--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -308,6 +308,7 @@ modules:
       mam: false
       max_users: 1000
       persistent: true
+    max_users: 1000
   mod_muc_admin: {}
   mod_muc_log:
     outdir: "/var/log/ejabberd/muc"


### PR DESCRIPTION
The room option for max_users in a MUC room is capped to the maximum of the service level max_users option. As this option wasn't set, the maximum users per MUC room were limited to 200. This commit fixes that.