### PR TITLE
Enable mod_mam for Message Archive Management

### DIFF
--- a/roles/ejabberd/files/ejabberd-delete-old-mam-messages.service
+++ b/roles/ejabberd/files/ejabberd-delete-old-mam-messages.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Deletion of MAM messages stored by ejabberd
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ejabberdctl delete_old_mam_messages all 31
+
+User=ejabberd
+Group=ejabberd
+
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateMounts=true
+PrivateTmp=true
+PrivateUsers=false
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=true

--- a/roles/ejabberd/files/ejabberd-delete-old-mam-messages.timer
+++ b/roles/ejabberd/files/ejabberd-delete-old-mam-messages.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run monthly deletion of MAM messages stored by ejabberd
+
+[Timer]
+OnCalendar=monthly
+RandomizedDelaySec=1h
+FixedRandomDelay=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/ejabberd/tasks/main.yml
+++ b/roles/ejabberd/tasks/main.yml
@@ -34,6 +34,29 @@
     state: started
     daemon_reload: true
 
+- name: Systemd service unit deleting old MAM messages
+  ansible.builtin.copy:
+    src: ejabberd-delete-old-mam-messages.service
+    dest: /etc/systemd/system/ejabberd-delete-old-mam-messages.service
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Systemd timer for deleting old MAM messages
+  ansible.builtin.copy:
+    src: ejabberd-delete-old-mam-messages.timer
+    dest: /etc/systemd/system/ejabberd-delete-old-mam-messages.timer
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Enable systemd timer for deleting old MAM messages
+  ansible.builtin.systemd:
+    name: ejabberd-delete-old-mam-messages.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+
 - name: Create /etc/default/ejabberd
   ansible.builtin.template:
     src: ejabberd-default.j2

--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -194,6 +194,8 @@ access_rules:
   ## Expected by the ipstamp module for XpartaMuPP
   ipbots:
     - allow: ipbots
+  mam_modify:
+    - deny
   muc_admin:
     - allow: admin
     - allow: muc_admins
@@ -283,7 +285,8 @@ modules:
   ## ipstamp module used by XpartaMuPP to insert IP addresses into the gamelist
   mod_ipstamp: {}
   mod_last: {}
-  ## mod_mam:
+  mod_mam:
+    access_preferences: mam_modify
   ##   ## Mnesia is limited to 2GB, better to use an SQL backend
   ##   ## For small servers SQLite is a good fit and is very easy
   ##   ## to configure. Uncomment this when you have SQL configured:


### PR DESCRIPTION
Enable mod_mam to support XEP-0313 "Message Archive Management", but prevent users from using it for now to avoid running into mnesia size limitations. Message Archiving Management can be enabled by MUC admins for MUC rooms though, but should only be enabled for rooms with moderate volume.