### PR TITLE
Add changes for profanity checking

### DIFF
--- a/config-lobby-vagrant.yml
+++ b/config-lobby-vagrant.yml
@@ -59,7 +59,8 @@ bots: [
       "rooms": ["arena"],
       "command_room": "moderation",
       "no_verify": true,
-      "verbosity": 3
+      "verbosity": 3,
+      "enable_profanity_monitoring": true
     }
   },
 ]

--- a/roles/lobby_bots/templates/echelon-systemd-service.j2
+++ b/roles/lobby_bots/templates/echelon-systemd-service.j2
@@ -27,11 +27,11 @@ ProtectKernelTunables=true
 ProtectSystem=full
 SystemCallArchitectures=native
 SystemCallFilter=access arch_prctl brk close connect epoll_create1 epoll_ctl epoll_wait fchmod
-SystemCallFilter=fcntl fdatasync futex getcwd getdents64 geteuid getpeername getpid getrandom
-SystemCallFilter=getsockname getsockopt gettid ioctl lseek mmap mprotect mremap munmap newfstatat
-SystemCallFilter=openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq rt_sigaction sendto
-SystemCallFilter=set_robust_list setsockopt set_tid_address socket socketpair sysinfo uname unlink
-SystemCallFilter=write
+SystemCallFilter=fcntl fdatasync fstat futex getcwd getdents64 geteuid getpeername getpid getrandom
+SystemCallFilter=getsockname getsockopt gettid ioctl lseek mkdir mmap mprotect mremap munmap
+SystemCallFilter=newfstatat openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq
+SystemCallFilter=rt_sigaction sendto set_robust_list setsockopt set_tid_address socket socketpair
+SystemCallFilter=sysinfo uname unlink write
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/lobby_bots/templates/moderation-systemd-service.j2
+++ b/roles/lobby_bots/templates/moderation-systemd-service.j2
@@ -27,11 +27,11 @@ ProtectKernelTunables=true
 ProtectSystem=full
 SystemCallArchitectures=native
 SystemCallFilter=access arch_prctl brk close connect epoll_create1 epoll_ctl epoll_wait fchmod
-SystemCallFilter=fcntl fdatasync futex getcwd getdents64 geteuid getpeername getpid getrandom
-SystemCallFilter=getsockname getsockopt gettid ioctl lseek mmap mprotect mremap munmap newfstatat
-SystemCallFilter=openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq rt_sigaction sendto
-SystemCallFilter=set_robust_list setsockopt set_tid_address socket socketpair sysinfo uname unlink
-SystemCallFilter=write
+SystemCallFilter=fcntl fdatasync fstat futex getcwd getdents64 geteuid getpeername getpid getrandom
+SystemCallFilter=getsockname getsockopt gettid ioctl lseek mkdir mmap mprotect mremap munmap
+SystemCallFilter=newfstatat openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq
+SystemCallFilter=rt_sigaction sendto set_robust_list setsockopt set_tid_address socket socketpair
+SystemCallFilter=sysinfo uname unlink write
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
+++ b/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
@@ -26,11 +26,11 @@ ProtectKernelTunables=true
 ProtectSystem=full
 SystemCallArchitectures=native
 SystemCallFilter=access arch_prctl brk close connect epoll_create1 epoll_ctl epoll_wait fchmod
-SystemCallFilter=fcntl fdatasync futex getcwd getdents64 geteuid getpeername getpid getrandom
-SystemCallFilter=getsockname getsockopt gettid ioctl lseek mmap mprotect mremap munmap newfstatat
-SystemCallFilter=openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq rt_sigaction sendto
-SystemCallFilter=set_robust_list setsockopt set_tid_address socket socketpair sysinfo uname unlink
-SystemCallFilter=write
+SystemCallFilter=fcntl fdatasync fstat futex getcwd getdents64 geteuid getpeername getpid getrandom
+SystemCallFilter=getsockname getsockopt gettid ioctl lseek mkdir mmap mprotect mremap munmap
+SystemCallFilter=newfstatat openat pread64 prlimit64 pwrite64 read readlink recvfrom rseq
+SystemCallFilter=rt_sigaction sendto set_robust_list setsockopt set_tid_address socket socketpair
+SystemCallFilter=sysinfo uname unlink write
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows the bots to use the fstat() and mkdir() syscalls, as that's required for the profanity check functionality in the moderation bot introduced with https://github.com/0ad/lobby-bots/commit/1ed99e3fa88060cb508cc1ca15f2d870498692fc

It also enables profanity checking when running the bots in Vagrant.