### PR TITLE
Terminate XMPP connections on ping timeout

### DIFF
--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -321,7 +321,9 @@ modules:
   mod_offline:
     access_max_user_messages: max_user_offline_messages
   mod_ping:
+    ping_ack_timeout: 30s
     send_pings: true
+    timeout_action: kill
 #  mod_pres_counter:
 #    count: 5
 #    interval: 60


### PR DESCRIPTION
While XMPP pings were already enabled, timed out pings didn't result in an action. This commit changes that, so connections with ping timeouts get closed. This should result in fewer zombie connections, caused by network problems.