### PR TITLE
Remove links to Trac

### DIFF
--- a/roles/lobby_bots/templates/echelon-systemd-service.j2
+++ b/roles/lobby_bots/templates/echelon-systemd-service.j2
@@ -1,6 +1,5 @@
 [Unit]
 Description=EcheLOn Pyrogenesis/0 A.D. Lobby Bot %i
-Documentation=https://trac.wildfiregames.com/
 After=network.target ejabberd.service
 
 [Service]

--- a/roles/lobby_bots/templates/moderation-systemd-service.j2
+++ b/roles/lobby_bots/templates/moderation-systemd-service.j2
@@ -1,6 +1,5 @@
 [Unit]
 Description=Pyrogenesis/0 A.D. Lobby Moderation Bot %i
-Documentation=https://trac.wildfiregames.com/
 After=network.target ejabberd.service
 
 [Service]

--- a/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
+++ b/roles/lobby_bots/templates/xpartamupp-systemd-service.j2
@@ -1,6 +1,5 @@
 [Unit]
 Description=XPartaMuPP Pyrogenesis/0 A.D. Lobby Bot %i
-Documentation=https://trac.wildfiregames.com/
 After=network.target ejabberd.service
 
 [Service]


### PR DESCRIPTION
Trac is deprecated and didn't hold documentation for the lobby bots anyway, so this removes the documentation links mentioning it.