### PR TITLE
Update username regex

### DIFF
--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -172,7 +172,7 @@ acl:
 
   # Keep player names short and easily typeable for everyone
   validname:
-    user_regexp: "^[0-9A-Za-z._-]{1,20}$"
+    user_regexp: "^(?=.*[A-Za-z])[A-Za-z0-9._-]{3,20}$"
 
   local:
     user_regexp: ""


### PR DESCRIPTION
As 0 A.D. Alpha 27 has been published a while ago, this adjusts the username regex to be in line with the changes from https://code.wildfiregames.com/D4999, which is part of Alpha 27.

User names of newly registered users have to comply with the following rules now:

- length: between 3 and 20 characters
- valid characters: lower- and uppercase letters, numbers, ".", "_", "-"
- must contain at least one letter