### PR TITLE
Add a separate log of ejabberd user registrations

### DIFF
--- a/roles/ejabberd_registration_log/files/ejabberd-registration-log.py
+++ b/roles/ejabberd_registration_log/files/ejabberd-registration-log.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Consume ejabberd logs and print newly registered users.
+
+The output is printed as CSV records, so it's human and
+machine-readable, with the IP-address of the registered user being
+resolved to an ASN, its operator and its country of origin.
+
+For testing, remove the match for the ejabberd service and add journal
+entries like this:
+
+    echo "The account foo was registered from IP address 1.2.3.4" | systemd-cat
+
+"""
+
+import csv
+import json
+import re
+import selectors
+import sys
+from functools import lru_cache
+from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
+from json import JSONDecodeError
+from typing import Any
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import systemd.journal
+from systemd.journal import Reader
+
+
+RIPESTAT_DATA_API_URL = "https://stat.ripe.net/data"
+
+
+@lru_cache
+def get_prefix_info(prefix: IPv4Address | IPv6Address) -> dict[str, Any]:
+    """Get IP prefix information from the RIPEStat Data API."""
+    response = urlopen(
+        f"{RIPESTAT_DATA_API_URL}/prefix-overview/data.json?resource={prefix}"
+    )
+    if response.getcode() != 200:
+        raise URLError("Status code isn't 200")
+    return json.loads(response.read())
+
+
+@lru_cache
+def get_country(prefix: str) -> str:
+    """Get the country of an IP prefix from the RIPEStat Data API."""
+    try:
+        response = urlopen(
+            f"{RIPESTAT_DATA_API_URL}/rir-geo/data.json?resource={prefix}"
+        )
+        if response.getcode() != 200:
+            return ""
+        return json.loads(response.read())["data"]["located_resources"][0]["location"]
+    except (AttributeError, JSONDecodeError, URLError):
+        return ""
+
+
+def get_asn(ipaddr: str) -> dict[str, Any] | None:
+    """Check if the ASN of an IP-address should be resolved.
+
+    Return ASN information if the IP-address belongs to a publicly
+    routed IP prefix, None otherwise.
+    """
+
+    try:
+        # Check only the possibly longest prefix (longer
+        # prefixes are usually not routed/visible via BGP) for
+        # better cacheability and to avoid sending users
+        # IP addresses.
+        prefixlen = 24 if ip_address(ipaddr).version == 4 else 48
+        prefix_to_check = ip_network(
+            f"{ipaddr}/{prefixlen}", strict=False
+        ).network_address
+    except ValueError:
+        return None
+
+    if (
+        prefix_to_check.is_multicast
+        or prefix_to_check.is_private
+        or prefix_to_check.is_unspecified
+        or prefix_to_check.is_reserved
+        or prefix_to_check.is_loopback
+        or prefix_to_check.is_link_local
+    ):
+        return None
+
+    try:
+        prefix_info = get_prefix_info(prefix_to_check)
+    except (AttributeError, JSONDecodeError, URLError):
+        return None
+
+    if not prefix_info["data"]["announced"]:
+        return None
+
+    return prefix_info
+
+
+def main():
+    reader = Reader()
+    reader.add_match("_SYSTEMD_UNIT=ejabberd.service")
+    reader.seek_tail()
+    reader.get_previous()
+
+    selector = selectors.DefaultSelector()
+    selector.register(reader, selectors.EVENT_READ)
+
+    registration_regex = re.compile(
+        r"The account (?P<username>\S+) was registered from IP address (?P<ip>[0-9a-f.:]+)$"
+    )
+
+    writer = csv.writer(sys.stdout)
+
+    while selector.select():
+        state = reader.process()
+        if state != systemd.journal.APPEND:
+            continue
+
+        for event in reader:
+            event_date = event["__REALTIME_TIMESTAMP"]
+            result = registration_regex.search(event["MESSAGE"])
+            if not result:
+                continue
+
+            username = result["username"]
+            ipaddr = result["ip"]
+
+            prefix_info = get_asn(ipaddr)
+
+            if not prefix_info:
+                writer.writerow([event_date.isoformat(), username, ipaddr, "", "", ""])
+                sys.stdout.flush()
+                continue
+
+            writer.writerow(
+                [
+                    event_date.isoformat(),
+                    username,
+                    ipaddr,
+                    str(prefix_info["data"]["asns"][0]["asn"]),
+                    prefix_info["data"]["asns"][0]["holder"],
+                    get_country(prefix_info["data"]["resource"]),
+                ]
+            )
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/roles/ejabberd_registration_log/files/ejabberd-registration-log.service
+++ b/roles/ejabberd_registration_log/files/ejabberd-registration-log.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=ejabberd registration logging
+
+[Service]
+Type=exec
+User=ejabberd-registration-log
+ExecStart=/opt/ejabberd-registration-log.py
+Restart=on-failure
+
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateMounts=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/ejabberd_registration_log/handlers/main.yml
+++ b/roles/ejabberd_registration_log/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart ejabberd-registration-log
+  ansible.builtin.systemd:
+    name: ejabberd-registration-log
+    state: restarted

--- a/roles/ejabberd_registration_log/tasks/main.yml
+++ b/roles/ejabberd_registration_log/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Add ejabberd-registration-log group
+  ansible.builtin.group:
+    name: ejabberd-registration-log
+    system: true
+    state: present
+
+- name: Add ejabberd-registration-log user
+  ansible.builtin.user:
+    name: ejabberd-registration-log
+    group: ejabberd-registration-log
+    groups:
+      - systemd-journal
+    create_home: false
+    shell: /bin/false
+    system: true
+
+- name: Copy ejabberd-registration-log.py
+  ansible.builtin.copy:
+    src: ejabberd-registration-log.py
+    dest: /opt/ejabberd-registration-log.py
+    owner: ejabberd-registration-log
+    group: ejabberd-registration-log
+    mode: 0755
+  notify: Restart ejabberd-registration-log
+
+- name: Create systemd service file
+  ansible.builtin.copy:
+    src: ejabberd-registration-log.service
+    dest: /etc/systemd/system/ejabberd-registration-log.service
+    owner: ejabberd-registration-log
+    group: ejabberd-registration-log
+    mode: 0644
+
+- name: Enable and start the systemd service
+  ansible.builtin.systemd:
+    name: ejabberd-registration-log
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/site.yml
+++ b/site.yml
@@ -14,6 +14,7 @@
     - certbot
     - openssl
     - ejabberd
+    - ejabberd_registration_log
     - python
     - lobby_bots
     - borgmatic


### PR DESCRIPTION
This adds a separate log of all ejabberd user registrations, enriched with information about the ASN, its operator and its country of origin, the user is connecting from. That's helpful for combating abuse of the service.