### PR TITLE
Work around client certificate problems

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,5 @@
 ---
 collections:
   - name: ansible.posix
+  - name: community.crypto
   - name: community.general

--- a/roles/ejabberd/tasks/main.yml
+++ b/roles/ejabberd/tasks/main.yml
@@ -113,6 +113,36 @@
     state: restarted
   when: localhost_cert_exists.stat.isreg is not defined
 
+- name: Create private key for a dummy CA
+  community.crypto.openssl_privatekey:
+    path: /etc/ejabberd/dummy-ca.key
+    owner: ejabberd
+    group: ejabberd
+    mode: 0644
+
+- name: Create certificate signing request (CSR) for a dummy CA certificate
+  community.crypto.openssl_csr_pipe:
+    privatekey_path: /etc/ejabberd/dummy-ca.key
+    common_name: Wildfire Games Lobby CA
+    use_common_name_for_san: false
+    basic_constraints:
+      - 'CA:TRUE'
+    basic_constraints_critical: true
+    key_usage:
+      - keyCertSign
+    key_usage_critical: true
+  register: ca_csr
+
+- name: Create self-signed root CA certificate for the dummy CA from CSR
+  community.crypto.x509_certificate:
+    path: /etc/ejabberd/dummy-ca.pem
+    csr_content: "{{ ca_csr.csr }}"
+    privatekey_path: /etc/ejabberd/dummy-ca.key
+    provider: selfsigned
+    owner: ejabberd
+    group: ejabberd
+    mode: 0644
+
 - name: Ensure ejabberd is enabled and running
   ansible.builtin.systemd:
     name: ejabberd

--- a/roles/ejabberd/templates/ejabberd.yml.j2
+++ b/roles/ejabberd/templates/ejabberd.yml.j2
@@ -73,6 +73,7 @@ listen:
     starttls: true
     starttls_required: true
     protocol_options: 'TLS_OPTIONS'
+    cafile: '/etc/ejabberd/dummy-ca.pem'
 #  -
 #    port: 5223
 #    ip: "::"


### PR DESCRIPTION
By default ejabberd requests certificates from clients, but doesn't use them. While that's usually not a problem, under certain circumstances 0ad on Windows, which does use SChannel for TLS, seems to have problems with that.

As we don't use client certificates the obvious solution would be to disable that ejabberd requests certificates from clients. However, this is not possible yet and [will only get introduced in the next version of ejabberd][1].

To work around this problem, this commit creates a dummy CA which then gets configured in ejabberd as the only CA to accept certificates from. This should cause clients not to send certificates at all, as they have no certificates available signed by our dummy CA.

The details of the generated root certificate pretty much don't matter, as ejabberd just extracts the common name to send to clients as part of the certificate request in the TLS handshake.

[1]:
https://github.com/processone/ejabberd/commit/5b03ca51e003bae785d186f183c0cd276fc89e97